### PR TITLE
Collecting foreign key

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 ## Convert Microsoft Access *.accdb or *.mdb into *.sql PostgreSQL format
 I believe in MS Access regarding its fast prototyping of relational database. You probably are not going to use MS Access in production environment due to its file based and single user restriction. But in a prototyping phase, MS Acces is one tool that is hard to beat!
 
-Quick and easily prototype your database using MS Access, once satisfied, use this tool to convert said database into PostgreSQL DDL. You can either save it to *.sql file, dump it to console or directly execute it to PostgreSQL instance
+Quick and easily prototype your database using MS Access, once satisfied, use this tool to convert said database into PostgreSQL DDL. You can either save it to *.sql file, dump it to console or directly execute it to PostgreSQL instance.
+
+Before you run this tool, you must preparing your Ms Access DB by grant read access to the Admin role for read relationship/foreign key information with executing scripts below in MsAccess Immediate panel
+    ?CurrentUser
+    CurrentProject.Connection.Execute "GRANT SELECT ON MSysRelationships TO Admin"
 
 If you use Django, you can then run `python manage.py inspectdb` to turn generated tables into Django models and .. voila, you can skip manually coding tedious Django models yourselves!
 


### PR DESCRIPTION
### Reference Issues
Collecting foreign key error when MS Access source's  foreign key field do not write with format id_table-reference.

### What does this implement/fix ?
Change routine collecting foreign key with query information from hidden MS Access system table "MSysRelationships", so it will more dynamic reading field name.

To read MSysRelationships from outside MS Access, we must grant read access to the Admin role for read relationship/foreign key information by executing scripts below in MsAccess Immediate panel : 
      ?CurrentUser
       CurrentProject.Connection.Execute "GRANT SELECT ON MSysRelationships TO Admin"

### Other comments 



